### PR TITLE
Internationalise the download label

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -28,6 +28,7 @@
 	"change-chart": "Chart type",
 	"settings": "Settings",
 	"download": "Download as $1",
+	"download2" : "Download",
 	"csv": "CSV",
 	"json": "JSON",
 	"credits": "Brought to you by $1, $2, and $3.",

--- a/views/_data_links.haml
+++ b/views/_data_links.haml
@@ -12,7 +12,7 @@
     %span.download-btn-group
       %span.input-group-addon
         %span.glyphicon.glyphicon-download-alt
-        Download
+          = $I18N->msg( 'download2' )
       %span.input-group-btn
         %button.btn.btn-default.btn-sm.download-csv
           = $I18N->msg( 'csv' )


### PR DESCRIPTION
This commit adds a new message called "download2" which is then used in the _data_links view, allowing the download buttons' label to be internationalised.

The "download" message has a different wording, which is why I've decided to create a new message.  It looks to me that "download" is no longer used in the app.  Perhaps "download" should be removed from the messages as well?  Not sure what is preferred by the maintainers, so I've not included such a deletion in this pull request.