### PR TITLE
Internationalise the download label

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -27,7 +27,7 @@
 	"page-title": "Page title",
 	"change-chart": "Chart type",
 	"settings": "Settings",
-	"download": "Download as $1",
+	"download-label": "Download",
 	"csv": "CSV",
 	"json": "JSON",
 	"credits": "Brought to you by $1, $2, and $3.",

--- a/messages/qqq.json
+++ b/messages/qqq.json
@@ -35,7 +35,7 @@
 	"page-title": "Heading for the column of page titles in the Langviews application\n{{Identical|Page title}}",
 	"change-chart": "Link that allows the user to choose a different type of chart",
 	"settings": "Link that opens an interface for the user to change their settings, for example, the date formatting\n{{Identical|Settings}}",
-	"download": "Link that downloads the pageview data to a file. $1 is the format of the file, for example 'CSV'.",
+	"download-label": "Label next to the download buttons.\n{{identical|Download}}",
 	"csv": "{{Optional}}\nLink for CSV file. See https://en.wikipedia.org/wiki/Comma-separated_values for information on what a CSV file is.\nCSV is the name of a file format; should not be translated.",
 	"json": "{{Optional}}\nLink for JSON file. See https://en.wikipedia.org/wiki/JSON for information on what a JSON file is.",
 	"credits": "Footer message crediting the programmers. $1, $2, and $3 are links to the programmers.",

--- a/views/_data_links.haml
+++ b/views/_data_links.haml
@@ -12,7 +12,7 @@
     %span.download-btn-group
       %span.input-group-addon
         %span.glyphicon.glyphicon-download-alt
-        Download
+          = $I18N->msg( 'download-label' )
       %span.input-group-btn
         %button.btn.btn-default.btn-sm.download-csv
           = $I18N->msg( 'csv' )


### PR DESCRIPTION
This pull request is a modified version of #145.

It adds a new message with key "download-label".  This message is then used to internationalise the label next to the download buttons.

At the same time, the obsolete message "download" is removed.