### PR TITLE
Internationalise the page information links

### DIFF
--- a/javascripts/templates.js
+++ b/javascripts/templates.js
@@ -19,11 +19,11 @@ const templates = {
         <strong>${$.i18n('totals')}:</strong>
         ${scope.formatNumber(dataset.sum)} (${scope.formatNumber(dataset.average)}/${$.i18n('day')})
         &bullet;
-        <a href="${scope.getLangviewsURL(dataset.label)}" target="_blank">All languages</a>
+        <a href="${scope.getLangviewsURL(dataset.label)}" target="_blank">${$.i18n('all-languages')}</a>
         &bullet;
-        <a href="${scope.getExpandedPageURL(dataset.label)}&action=history" target="_blank">History</a>
+        <a href="${scope.getExpandedPageURL(dataset.label)}&action=history" target="_blank">${$.i18n('history')}</a>
         &bullet;
-        <a href="${scope.getExpandedPageURL(dataset.label)}&action=info" target="_blank">Info</a>
+        <a href="${scope.getExpandedPageURL(dataset.label)}&action=info" target="_blank">${$.i18n('info')}</a>
       </div>`;
     }
 


### PR DESCRIPTION
This pull request internationalises three messages, found in the per-page information links.  The messages for these links have already been added to the messages database, so they only require referencing in the template.