### PR TITLE
Update remaining links to old Toolforge domain

### DIFF
--- a/public_html/mediaviews/api.php
+++ b/public_html/mediaviews/api.php
@@ -4,6 +4,6 @@
 $ch = curl_init();
 curl_setopt($ch, CURLOPT_HTTPHEADER, ['Accept: application/json']);
 curl_setopt($ch, CURLOPT_URL, $_GET['endpoint']);
-curl_setopt($ch, CURLOPT_USERAGENT, 'Mediaviews Analysis; https://tools.wmflabs.org/mediaviews / https://en.wikipedia.org/wiki/User_talk:MusikAnimal');
+curl_setopt($ch, CURLOPT_USERAGENT, 'Mediaviews Analysis; https://mediaviews.toolforge.org / https://en.wikipedia.org/wiki/User_talk:MusikAnimal');
 $result = curl_exec($ch);
 curl_close($ch);

--- a/public_html/toolinfo.json
+++ b/public_html/toolinfo.json
@@ -3,7 +3,7 @@
         "name" : "pageviews",
         "title": "Pageviews Analysis",
         "description": "Analysis of pageviews across multiple pages",
-        "url": "https://tools.wmflabs.org/pageviews",
+        "url": "https://pageviews.toolforge.org",
         "keywords": "pageviews,page views,traffic,visitors,statistics,analytics,stats,views",
         "author": "MusikAnimal, Kaldari, Marcel Ruiz Forns",
         "repository": "https://github.com/MusikAnimal/pageviews"
@@ -12,7 +12,7 @@
         "name" : "langviews",
         "title": "Langviews Analysis",
         "description": "Pageviews of an article across all languages",
-        "url": "https://tools.wmflabs.org/langviews",
+        "url": "https://langviews.toolforge.org",
         "keywords": "langviews,pageviews,page views,traffic,visitors,statistics,analytics,stats,views",
         "author": "MusikAnimal",
         "repository": "https://github.com/MusikAnimal/pageviews"
@@ -21,7 +21,7 @@
         "name" : "topveiws",
         "title": "Topviews Analysis",
         "description": "Most viewed pages of a project",
-        "url": "https://tools.wmflabs.org/topviews",
+        "url": "https://topviews.toolforge.org",
         "keywords": "topviews,pageviews,page views,traffic,visitors,statistics,analytics,stats,views",
         "author": "MusikAnimal",
         "repository": "https://github.com/MusikAnimal/pageviews"
@@ -30,7 +30,7 @@
         "name" : "siteviews",
         "title": "Siteviews Analysis",
         "description": "Analysis of total pageviews across multiple projects",
-        "url": "https://tools.wmflabs.org/siteviews",
+        "url": "https://siteviews.toolforge.org",
         "keywords": "siteviews,pageviews,page views,traffic,visitors,statistics,analytics,stats,views",
         "author": "MusikAnimal",
         "repository": "https://github.com/MusikAnimal/pageviews"
@@ -39,7 +39,7 @@
         "name" : "massviews",
         "title": "Massviews Analysis",
         "description": "Import a list of pages and analyze the pageviews",
-        "url": "https://tools.wmflabs.org/massviews",
+        "url": "https://massviews.toolforge.org",
         "keywords": "massviews,pageviews,page views,traffic,visitors,statistics,analytics,stats,views,glam",
         "author": "MusikAnimal",
         "repository": "https://github.com/MusikAnimal/pageviews"
@@ -48,7 +48,7 @@
         "name" : "redirectviews",
         "title": "Redirect Views",
         "description": "Get the pageviews of all redirects to a page",
-        "url": "https://tools.wmflabs.org/redirectviews",
+        "url": "https://redirectviews.toolforge.org",
         "keywords": "redirectviews,redirects,pageviews,page views,traffic,visitors,statistics,analytics,stats,views",
         "author": "MusikAnimal",
         "repository": "https://github.com/MusikAnimal/pageviews"
@@ -57,7 +57,7 @@
         "name" : "userviews",
         "title": "Userviews",
         "description": "Get the pageviews of all pages created by a user",
-        "url": "https://tools.wmflabs.org/userviews",
+        "url": "https://userviews.toolforge.org",
         "keywords": "userviews,pages created,pageviews,page views,traffic,visitors,statistics,analytics,stats,views",
         "author": "MusikAnimal",
         "repository": "https://github.com/MusikAnimal/pageviews"
@@ -66,7 +66,7 @@
         "name": "mediaviews",
         "title": "Mediaviews",
         "description": "Get the playcounts of audio and video on Commons",
-        "url": "https://tools.wmflabs.org/mediaviews",
+        "url": "https://mediaviews.toolforge.org",
         "keywords": "mediaviews,traffic,visitors,statistics,analytics,stats,views,playcounts,commons",
         "author": "MusikAnimal",
         "repository": "https://github.com/MusikAnimal/pageviews"


### PR DESCRIPTION
tools.wmflabs,org is still used in 2 files: [public_html/mediaviews/api.php](https://github.com/MusikAnimal/pageviews/blob/master/public_html/mediaviews/api.php) and [public_html/toolinfo.json](https://github.com/MusikAnimal/pageviews/blob/master/public_html/toolinfo.json)